### PR TITLE
Add missing exception class used in the plugin

### DIFF
--- a/lib/sequel/plugins/audit_by_day.rb
+++ b/lib/sequel/plugins/audit_by_day.rb
@@ -3,6 +3,8 @@ module Sequel
     module AuditByDay
       require "set"
 
+      class AuditKindNotFound < ::StandardError; end
+
       def self.configure(master, opts={})
         audit_foreign_key = opts[:foreign_key]
         default_valid_from = opts.fetch(:default_valid_from){ Time.utc(1000) }


### PR DESCRIPTION
The plugin raises an AuditKindNotFound exception on line 51, but AuditKindNotFound is not defined.
This commit adds the class.
