### PR TITLE
fix column_updated_at to work like in docs

### DIFF
--- a/lib/sequel/plugins/audit_by_day.rb
+++ b/lib/sequel/plugins/audit_by_day.rb
@@ -57,7 +57,7 @@ module Sequel
                 attrs[column] = nil
               end
             end
-            attrs["#{column_name}_at"] = ::Sequel::Plugins::Bitemporal.point_in_time
+            attrs["#{column_name}_updated_at"] = ::Sequel::Plugins::Bitemporal.point_in_time
           end
           audit_for_day.update_attributes attrs.merge(valid_from: audit_default_valid_from)
         end


### PR DESCRIPTION
I tried to use gem like it was specified in docs, but it couldn't find the column. Shouldn't it be named the way I fixed it?